### PR TITLE
Added missing printyellow function to utils

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -141,3 +141,6 @@ def chrome_browser_options():
     return options
 
 
+
+def printyellow(text):
+    print(f"\033[93m{text}\033[0m")


### PR DESCRIPTION
Added a missing utility function `printyellow()` to src/utils.py that enables yellow-colored console output. This function is used throughout the application for warning and notification messages.

Changes made:
- Added printyellow() function to src/utils.py
- Function takes a text parameter and prints it in yellow using ANSI color codes
- Maintains consistent styling with other print utility functions

Testing:
- Verified yellow text output in terminal
- Tested with various text inputs including multi-line strings
- Confirmed compatibility with both Windows and Unix-based systems

This PR resolves the missing utility function error and standardizes warning message display across the application.
ISSUE SOLVED:  #758