### PR TITLE
Fix: Commented the error printyellow Import and Updated the Plain_text_resume Example

### DIFF
--- a/data_folder_example/plain_text_resume.yaml
+++ b/data_folder_example/plain_text_resume.yaml
@@ -82,8 +82,10 @@ achievements:
     description: "Won first place in a national hackathon competition."
 
 certifications:
-  #- "Certified Scrum Master"
-  #- "AWS Certified Solutions Architect"
+  - name: "Certified Scrum Master"
+    description: "Recognized certification for proficiency in Agile methodologies and Scrum framework."
+  - name: "AWS Certified Solutions Architect"
+    description: "Certification demonstrating expertise in designing, deploying, and managing applications on AWS."
 
 languages:
   - language: "English"

--- a/src/ai_hawk/job_manager.py
+++ b/src/ai_hawk/job_manager.py
@@ -86,38 +86,38 @@ class AIHawkJobManager:
         for position, location in searches:
             location_url = "&location=" + location
             job_page_number = -1
-            utils.printyellow(f"Collecting data for {position} in {location}.")
+            # utils.printyellow(f"Collecting data for {position} in {location}.")
             try:
                 while True:
                     page_sleep += 1
                     job_page_number += 1
-                    utils.printyellow(f"Going to job page {job_page_number}")
+                    # utils.printyellow(f"Going to job page {job_page_number}")
                     self.next_job_page(position, location_url, job_page_number)
                     utils.medium_sleep()
-                    utils.printyellow("Starting the collecting process for this page")
+                    # utils.printyellow("Starting the collecting process for this page")
                     self.read_jobs()
-                    utils.printyellow("Collecting data on this page has been completed!")
+                    # utils.printyellow("Collecting data on this page has been completed!")
 
                     time_left = minimum_page_time - time.time()
                     if time_left > 0:
-                        utils.printyellow(f"Sleeping for {time_left} seconds.")
+                        # utils.printyellow(f"Sleeping for {time_left} seconds.")
                         time.sleep(time_left)
                         minimum_page_time = time.time() + minimum_time
                     if page_sleep % 5 == 0:
                         sleep_time = random.randint(1, 5)
-                        utils.printyellow(f"Sleeping for {sleep_time / 60} minutes.")
+                        # utils.printyellow(f"Sleeping for {sleep_time / 60} minutes.")
                         time.sleep(sleep_time)
                         page_sleep += 1
             except Exception:
                 pass
             time_left = minimum_page_time - time.time()
             if time_left > 0:
-                utils.printyellow(f"Sleeping for {time_left} seconds.")
+                # utils.printyellow(f"Sleeping for {time_left} seconds.")
                 time.sleep(time_left)
                 minimum_page_time = time.time() + minimum_time
             if page_sleep % 5 == 0:
                 sleep_time = random.randint(50, 90)
-                utils.printyellow(f"Sleeping for {sleep_time / 60} minutes.")
+                # utils.printyellow(f"Sleeping for {sleep_time / 60} minutes.")
                 time.sleep(sleep_time)
                 page_sleep += 1
 


### PR DESCRIPTION
This fix addresses an import error in job_manager.py, where an errored import for printyellow from src.utils was causing issues. The printyellow import has been commented out, as it is not necessary for the script's functionality. Additionally, minor updates were made to the Plain_text_resume example to improve clarity and usability, ensuring both files execute without errors.